### PR TITLE
fix bug of iam_user tag in tfstate

### DIFF
--- a/lib/practice_terraforming/resource/iam_user.rb
+++ b/lib/practice_terraforming/resource/iam_user.rb
@@ -33,8 +33,7 @@ module PracticeTerraforming
             "name" => user.user_name,
             "path" => user.path,
             "unique_id" => user.user_id,
-            "force_destroy" => "false",
-            "tags" => iam_tags_of(user).map { |t| [t.key, t.value] }.to_h
+            "force_destroy" => "false"
           }
           resources["aws_iam_user.#{module_name_of(user)}"] = {
             "type" => "aws_iam_user",

--- a/spec/lib/practice_terraforming/resource/iam_user_spec.rb
+++ b/spec/lib/practice_terraforming/resource/iam_user_spec.rb
@@ -84,10 +84,7 @@ module PracticeTerraforming
                                                                         "name" => "hoge",
                                                                         "path" => "/",
                                                                         "unique_id" => "ABCDEFGHIJKLMN1234567",
-                                                                        "force_destroy" => "false",
-                                                                        "tags" => {
-                                                                          "Name" => "Test"
-                                                                        }
+                                                                        "force_destroy" => "false"
                                                                       }
                                                                     }
                                                                   },
@@ -101,10 +98,7 @@ module PracticeTerraforming
                                                                         "name" => "fuga.piyo",
                                                                         "path" => "/system/",
                                                                         "unique_id" => "OPQRSTUVWXYZA8901234",
-                                                                        "force_destroy" => "false",
-                                                                        "tags" => {
-                                                                          "Name" => "Test"
-                                                                        }
+                                                                        "force_destroy" => "false"
                                                                       }
                                                                     }
                                                                   }


### PR DESCRIPTION
# issue

with v0.1.17

```
± terraform init

Initializing the backend...
Backend configuration changed!

Terraform has detected that the configuration specified for the backend
has changed. Terraform will now check for existing state in the backends.



Error: Error loading state:
    Invalid state file format: The state file field "attributes" has invalid value object

Terraform failed to load the default state from the "local" backend.
State migration cannot occur unless the state can be loaded. Backend
modification and state migration has been aborted. The state in both the
source and the destination remain unmodified. Please resolve the
above error and try again.
```

# what

removed tags from tfstate

```
------------------------------------------------------------------------

No changes. Infrastructure is up-to-date.

This means that Terraform did not detect any differences between your
configuration and real physical resources that exist. As a result, no
actions need to be performed.
```